### PR TITLE
Add memory guard to extract_records loop

### DIFF
--- a/classes/task/process_logs.php
+++ b/classes/task/process_logs.php
@@ -27,6 +27,9 @@ use tool_s3logs\local\client\s3_client;
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class process_logs extends \core\task\scheduled_task {
+    /** @var float The memory limit threshold as a fraction of the configured memory limit. */
+    const MEMORY_LIMIT_THRESHOLD = 0.8; // Stop processing if we have used 80% of the memory limit.
+
     /**
      * {@inheritDoc}
      * @see \core\task\scheduled_task::get_name()
@@ -103,6 +106,28 @@ class process_logs extends \core\task\scheduled_task {
     }
 
     /**
+     * Determines whether the memory usage for self::extract_records() has exceeded the defined threshold.
+     *
+     * @return bool Returns true when memory usage reaches self::MEMORY_LIMIT_THRESHOLD of memory limit; otherwise false.
+     */
+    public static function has_memory_exceeded(): bool {
+        $memlimit = ini_get('memory_limit');
+
+        if ($memlimit === false || $memlimit === '-1' || $memlimit === '') {
+            // No memory limit.
+            return false;
+        }
+
+        $reallimit = get_real_size($memlimit);
+        if ($reallimit <= 0) {
+            // Invalid or unusable configured limit.
+            return false;
+        }
+
+        return memory_get_usage(true) >= ($reallimit * self::MEMORY_LIMIT_THRESHOLD);
+    }
+
+    /**
      * Extract the log records from the db and write
      * to a temporary file.
      *
@@ -132,6 +157,12 @@ class process_logs extends \core\task\scheduled_task {
         // Get 1000 rows of data from the log table order by oldest first.
         // Keep getting records 1000 at a time until we run out of records or max execution time is reached.
         while (time() <= $stopat) {
+            if (self::has_memory_exceeded()) {
+                $memlimitthr = round(self::MEMORY_LIMIT_THRESHOLD * 100, 0);
+                mtrace("Memory limit threshold of {$memlimitthr}% reached, stopping processing to avoid an out-of-memory error");
+                break;
+            }
+
             $results = $DB->get_records_select(
                 'logstore_standard_log',
                 'timecreated <= ?' . $coursefiltersql,

--- a/tests/process_logs_test.php
+++ b/tests/process_logs_test.php
@@ -371,6 +371,108 @@ final class process_logs_test extends \advanced_testcase {
         }
     }
 
+    // Memory guard tests.
+
+    /**
+     * has_memory_exceeded returns true when current usage is already above the 80% threshold.
+     *
+     * @covers \tool_s3logs\task\process_logs::has_memory_exceeded
+     */
+    public function test_has_memory_exceeded_returns_true_above_threshold(): void {
+        $original = ini_get('memory_limit');
+        // Set the limit to 120% of current usage so the 80% threshold falls below current usage.
+        // Use try/finally to guarantee restoration even if an assertion fails.
+        $result = ini_set('memory_limit', (string)(int)ceil(memory_get_usage(true) * 1.2));
+        $this->assertNotFalse($result, 'ini_set(memory_limit) failed; fix the environment configuration.');
+        try {
+            $exceeded = process_logs::has_memory_exceeded();
+            $this->assertTrue($exceeded);
+        } finally {
+            ini_set('memory_limit', $original);
+        }
+    }
+
+    /**
+     * has_memory_exceeded returns false when current usage is well below the 80% threshold.
+     *
+     * @covers \tool_s3logs\task\process_logs::has_memory_exceeded
+     */
+    public function test_has_memory_exceeded_returns_false_below_threshold(): void {
+        $original = ini_get('memory_limit');
+        // Set the limit to 200% of current usage so current usage is well under the 80% threshold.
+        // Use try/finally to guarantee restoration even if an assertion fails.
+        $result = ini_set('memory_limit', (string)(int)ceil(memory_get_usage(true) * 2));
+        $this->assertNotFalse($result, 'ini_set(memory_limit) failed; fix the environment configuration.');
+        try {
+            $exceeded = process_logs::has_memory_exceeded();
+            $this->assertFalse($exceeded);
+        } finally {
+            ini_set('memory_limit', $original);
+        }
+    }
+
+    /**
+     * has_memory_exceeded returns false when the PHP memory limit is unlimited (-1).
+     *
+     * @covers \tool_s3logs\task\process_logs::has_memory_exceeded
+     */
+    public function test_has_memory_exceeded_returns_false_when_unlimited(): void {
+        $original = ini_get('memory_limit');
+        $result = ini_set('memory_limit', '-1');
+        $this->assertNotFalse($result, 'ini_set(memory_limit) failed; fix the environment configuration.');
+        // Use try/finally to guarantee restoration even if an assertion fails.
+        try {
+            $exceeded = process_logs::has_memory_exceeded();
+            $this->assertFalse($exceeded);
+        } finally {
+            ini_set('memory_limit', $original);
+        }
+    }
+
+    /**
+     * extract_records stops early and traces a warning when the memory threshold is exceeded.
+     *
+     * @covers \tool_s3logs\task\process_logs::extract_records
+     * @covers \tool_s3logs\task\process_logs::has_memory_exceeded
+     */
+    public function test_extract_records_stops_on_memory_exceeded(): void {
+        global $DB;
+        $this->resetAfterTest();
+
+        $ctx = \context_system::instance();
+        $DB->insert_record('logstore_standard_log', (object)[
+            'edulevel'          => 0,
+            'contextid'         => $ctx->id,
+            'contextlevel'      => $ctx->contextlevel,
+            'contextinstanceid' => $ctx->instanceid,
+            'userid'            => 1,
+            'timecreated'       => time() - self::DEFAULT_INTERVAL - 1,
+            'courseid'          => 0,
+        ]);
+
+        // Do setup allocations first so the memory headroom is predictable when we lower the limit.
+        $config   = (object)['courseids' => '', 'coursefiltermode' => 'include'];
+        $tempdir  = make_temp_directory('s3logs_test');
+        $tempfile = tempnam($tempdir, 's3logs_test_');
+        $fp       = fopen($tempfile, 'w');
+
+        $original = ini_get('memory_limit');
+        // Set the limit to 120% of current real usage so the 80% threshold is immediately exceeded.
+        // Using memory_get_usage(true) matches what has_memory_exceeded() uses internally.
+        // Use try/finally to guarantee restoration even if an assertion fails.
+        $result = ini_set('memory_limit', (string)(int)ceil(memory_get_usage(true) * 1.2));
+        $this->assertNotFalse($result, 'ini_set(memory_limit) must succeed for this test to be valid');
+        try {
+            $this->expectOutputRegex('/Memory limit threshold.*reached/');
+            $ids = $this->invoke_private('extract_records', [time() + 3600, self::DEFAULT_INTERVAL, $fp, $config]);
+            fclose($fp);
+
+            $this->assertEmpty($ids);
+        } finally {
+            ini_set('memory_limit', $original);
+        }
+    }
+
     /**
      * An empty prefix produces a keyname starting with an underscore.
      *


### PR DESCRIPTION
## Summary
 
 Adds a memory guard to the `extract_records()` loop in the `process_logs` scheduled task to prevent PHP out-of-memory errors on large log tables.
 
 ## Problem
 
 `extract_records()` accumulates all processed record IDs in `$recordids[]` and fetches log records in 1,000-row batches. On busy sites with millions of old log entries, this can exhaust PHP's memory limit mid-run, causing an unhandled fatal error.
 
 ## Solution
 
 - Added a `MEMORY_LIMIT_THRESHOLD` constant (`0.8`) and a `has_memory_exceeded()` public static method that compares `memory_get_usage()` against 80% of the configured `memory_limit` ini value.
 - The guard is checked at the start of each batch iteration. If the threshold is reached, extraction stops gracefully and the records collected so far are uploaded to S3 and deleted from the DB as normal. Remaining records are picked up on the next scheduled run.
 - No data loss: deletion only occurs after a successful S3 upload (ACID properties preserved).
 
 ## Changes
 
 - `classes/task/process_logs.php` — `MEMORY_LIMIT_THRESHOLD` constant, `has_memory_exceeded()` method, guard in extraction loop
 - `tests/process_logs_test.php` — 4 new tests: `has_memory_exceeded()` above threshold, below threshold, unlimited (`-1`), and an integration test verifying `extract_records()` stops early with a traced warning
 
 ## Testing
 

docker exec cqu-he-45 /var/www/cqu-he-45/vendor/bin/phpunit 
/var/www/cqu-he-45/admin/tool/s3logs/tests/process_logs_test.php

 
 All 20 tests pass.